### PR TITLE
[codex] Add book2skill external reference

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -88,6 +88,8 @@ Additional external source (included with the author's permission):
 
 - Source repository: [ace3000chao/book2startup](https://github.com/ace3000chao/book2startup)
 - Included books: *The Lean Startup*, *The Art of War*, *Zhuangzi*, and *I Ching*
+- Source repository: [shenqistart/book2skill](https://github.com/shenqistart/book2skill)
+- Included books: *Chanlun* and *The Classic of Tea*
 
 ## Repository Structure
 
@@ -127,6 +129,7 @@ They interlock: nuwa distills people, cangjie distills books, darwin keeps them 
 External Source (included with the author's permission):
 
 - [book2startup](https://github.com/ace3000chao/book2startup) — includes skills distilled from *The Lean Startup*, *The Art of War*, *Zhuangzi*, and *I Ching*
+- [book2skill](https://github.com/shenqistart/book2skill) — includes AI-Agent skills distilled from *Chanlun* and *The Classic of Tea*
 
 ## About the Author
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -88,6 +88,8 @@ RIA-TV++ の名前の由来：
 
 - 元リポジトリ: [ace3000chao/book2startup](https://github.com/ace3000chao/book2startup)
 - 書目: 『リーン・スタートアップ』『孫子兵法』『荘子』『易経』
+- 元リポジトリ: [shenqistart/book2skill](https://github.com/shenqistart/book2skill)
+- 書目: 『纏論』『茶経』
 
 ## リポジトリ構造
 
@@ -127,6 +129,7 @@ cangjie-skill はより大きなスキルエコシステムの一部です：
 External Source（著者本人の許可を得て掲載）:
 
 - [book2startup](https://github.com/ace3000chao/book2startup) — 『リーン・スタートアップ』『孫子兵法』『荘子』『易経』を蒸留した skills を含む
+- [book2skill](https://github.com/shenqistart/book2skill) — 『纏論』『茶経』を蒸留した AI-Agent skills を含む
 
 ## 作者について
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ RIA-TV++ 这个名字拆开看：
 
 - 来源仓库：[ace3000chao/book2startup](https://github.com/ace3000chao/book2startup)
 - 书目包括：《精益创业》《孙子兵法》《庄子》《易经》
+- 来源仓库：[shenqistart/book2skill](https://github.com/shenqistart/book2skill)
+- 书目包括：《缠论》《茶经》
 
 ## 仓库结构
 
@@ -133,6 +135,7 @@ cangjie-skill 是一个更大的 skill 生态的一部分：
 - [Huangdi Neijing Skill](https://github.com/kangarooking/huangdi-neijing-skill) — 《黄帝内经》素问12+灵枢10共22个思维方法 skill
 - [First Principles Skill](https://github.com/kangarooking/first-principles-skill) — 《第一性原理》的 10 个认知拆解、破界创新与组织刷新 skill
 - [book2startup](https://github.com/ace3000chao/book2startup) — 经作者同意引入的外部来源，包含《精益创业》《孙子兵法》《庄子》《易经》相关 skills
+- [book2skill](https://github.com/shenqistart/book2skill) — 经作者同意引入的外部来源，包含《缠论》《茶经》相关 AI-Agent skills
 
 ## 关于作者
 


### PR DESCRIPTION
## Summary

- Add shenqistart/book2skill as an external source repository.
- List its current books: 《缠论》 and 《茶经》.
- Add book2skill to the More Skills section.

## Validation

- README-only change.
- Checked for TODO/template placeholders with rg.
