### PR TITLE
Add qbdx-hub book skill examples

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -88,6 +88,12 @@ The name RIA-TV++ breaks down as:
 | Huangdi Neijing Lingshu (in this project) | Huangdi Neijing: Lingshu | 8 |
 | [first-principles-skill](https://github.com/kangarooking/first-principles-skill) | First Principles | 10 |
 | [mao-selected-works-skill](https://github.com/kangarooking/mao-selected-works-skill) | Selected Works of Mao Zedong, Vol. 1-5 | 25 |
+| [qbdx-hub/buffett-letters-skill](https://github.com/qbdx-hub/buffett-letters-skill) | Buffett Shareholder Letters (1957-2023) | 20 |
+| [qbdx-hub/wo-yu-di-tan-skill](https://github.com/qbdx-hub/wo-yu-di-tan-skill) | Wo Yu Di Tan | 6 |
+| [qbdx-hub/mingchao-those-things-skill](https://github.com/qbdx-hub/mingchao-those-things-skill) | Mingchao Those Things | 7 |
+| [qbdx-hub/sunzi-bingfa-skill](https://github.com/qbdx-hub/sunzi-bingfa-skill) | Sunzi Bingfa | 8 |
+| [qbdx-hub/zhouyi-skill](https://github.com/qbdx-hub/zhouyi-skill) | Zhouyi | 8 |
+| [qbdx-hub/high-math-vol1-ch1-skill](https://github.com/qbdx-hub/high-math-vol1-ch1-skill) | High Math Vol. 1 Chapter 1 | 8 |
 
 More high-value books are planned for distillation.
 
@@ -139,6 +145,12 @@ They interlock: nuwa distills people, cangjie distills books, darwin keeps them 
 - Huangdi Neijing Lingshu Skill (in this project) — 8 body-mind regulation and syndrome differentiation skills from *Huangdi Neijing: Lingshu*
 - [First Principles Skill](https://github.com/kangarooking/first-principles-skill) — 10 skills on axiomatic reasoning, boundary-breaking innovation, and organizational refresh from *First Principles*
 - [Mao Selected Works Skill](https://github.com/kangarooking/mao-selected-works-skill) — 25 cognition, strategy, organization, and execution skills from *Selected Works of Mao Zedong*
+- [qbdx-hub Buffett Letters Skill](https://github.com/qbdx-hub/buffett-letters-skill) — 20 investment and capital allocation skills from Buffett shareholder letters
+- [qbdx-hub Wo Yu Di Tan Skill](https://github.com/qbdx-hub/wo-yu-di-tan-skill) — 6 skills on limits, suffering, writing, and self-anchoring from *Wo Yu Di Tan*
+- [qbdx-hub Mingchao Those Things Skill](https://github.com/qbdx-hub/mingchao-those-things-skill) — 7 skills on power structure, institutional failure, and historical explanation from *Mingchao Those Things*
+- [qbdx-hub Sunzi Bingfa Skill](https://github.com/qbdx-hub/sunzi-bingfa-skill) — 8 skills on strategic judgment, resource control, and action selection from *Sunzi Bingfa*
+- [qbdx-hub Zhouyi Skill](https://github.com/qbdx-hub/zhouyi-skill) — 8 skills on situational diagnosis, timing, and advance-retreat boundaries from *Zhouyi*
+- [qbdx-hub High Math Vol. 1 Chapter 1 Skill](https://github.com/qbdx-hub/high-math-vol1-ch1-skill) — 8 learning skills on limits, infinitesimals, and continuity from High Math Vol. 1 Chapter 1
 
 External Source (included with the author's permission):
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -88,6 +88,12 @@ RIA-TV++ の名前の由来：
 | 黄帝内経・霊枢（本プロジェクト内） | 『黄帝内経・霊枢』 | 8 |
 | [first-principles-skill](https://github.com/kangarooking/first-principles-skill) | 『第一性原理』 | 10 |
 | [mao-selected-works-skill](https://github.com/kangarooking/mao-selected-works-skill) | 『毛沢東選集』第1-5巻 | 25 |
+| [qbdx-hub/buffett-letters-skill](https://github.com/qbdx-hub/buffett-letters-skill) | バフェット株主への手紙（1957-2023） | 20 |
+| [qbdx-hub/wo-yu-di-tan-skill](https://github.com/qbdx-hub/wo-yu-di-tan-skill) | 『我与地坛』 | 6 |
+| [qbdx-hub/mingchao-those-things-skill](https://github.com/qbdx-hub/mingchao-those-things-skill) | 『明朝那些事儿』 | 7 |
+| [qbdx-hub/sunzi-bingfa-skill](https://github.com/qbdx-hub/sunzi-bingfa-skill) | 『孫子兵法』 | 8 |
+| [qbdx-hub/zhouyi-skill](https://github.com/qbdx-hub/zhouyi-skill) | 『周易』 | 8 |
+| [qbdx-hub/high-math-vol1-ch1-skill](https://github.com/qbdx-hub/high-math-vol1-ch1-skill) | 高等数学上冊第1章 | 8 |
 
 より多くの高価値な本の蒸留を計画中。
 
@@ -139,6 +145,12 @@ cangjie-skill はより大きなスキルエコシステムの一部です：
 - Huangdi Neijing Lingshu Skill（本プロジェクト内）— 『黄帝内経・霊枢』から抽出した8個の心身調整・弁証スキル
 - [First Principles Skill](https://github.com/kangarooking/first-principles-skill) — 『第一性原理』から抽出した10個の公理化思考・破界イノベーション・組織刷新スキル
 - [Mao Selected Works Skill](https://github.com/kangarooking/mao-selected-works-skill) — 『毛沢東選集』第1-5巻から抽出した25個の認知・戦略・組織・実行スキル
+- [qbdx-hub Buffett Letters Skill](https://github.com/qbdx-hub/buffett-letters-skill) — バフェット株主への手紙から抽出した20個の投資・資本配分スキル
+- [qbdx-hub Wo Yu Di Tan Skill](https://github.com/qbdx-hub/wo-yu-di-tan-skill) — 『我与地坛』から抽出した6個の制約・苦難・執筆・自己定位スキル
+- [qbdx-hub Mingchao Those Things Skill](https://github.com/qbdx-hub/mingchao-those-things-skill) — 『明朝那些事儿』から抽出した7個の権力構造・制度失敗・歴史説明スキル
+- [qbdx-hub Sunzi Bingfa Skill](https://github.com/qbdx-hub/sunzi-bingfa-skill) — 『孫子兵法』から抽出した8個の戦略判断・資源制御・行動選択スキル
+- [qbdx-hub Zhouyi Skill](https://github.com/qbdx-hub/zhouyi-skill) — 『周易』から抽出した8個の状況診断・時機判断・進退境界スキル
+- [qbdx-hub High Math Vol. 1 Chapter 1 Skill](https://github.com/qbdx-hub/high-math-vol1-ch1-skill) — 高等数学上冊第1章から抽出した8個の極限・無限小・連続性学習スキル
 
 External Source（著者本人の許可を得て掲載）:
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ cangjie-skill 是一个更大的 skill 生态的一部分：
 感谢以下贡献者对 cangjie-skill 生态的补充：
 
 - [shenqistart](https://github.com/shenqistart) — 贡献外部 [book2skill](https://github.com/shenqistart/book2skill) 引用，并补充中英日 README 更新
+- [qbdx-hub](https://github.com/qbdx-hub) — 贡献 6 个 Cangjie 整书/章节蒸馏示例仓库，并补充中英日 README 引用
 
 ## 关于作者
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ RIA-TV++ 这个名字拆开看：
 | [huangdi-neijing-skill](https://github.com/kangarooking/huangdi-neijing-skill) | 《黄帝内经》（素问+灵枢） | 22 |
 | [first-principles-skill](https://github.com/kangarooking/first-principles-skill) | 《第一性原理》 | 10 |
 | [mao-selected-works-skill](https://github.com/kangarooking/mao-selected-works-skill) | 《毛泽东选集》第 1-5 卷 | 25 |
+| [qbdx-hub/buffett-letters-skill](https://github.com/qbdx-hub/buffett-letters-skill) | 沃伦·巴菲特 1957-2023 年致股东信 | 20 |
+| [qbdx-hub/wo-yu-di-tan-skill](https://github.com/qbdx-hub/wo-yu-di-tan-skill) | 史铁生《我与地坛》 | 6 |
+| [qbdx-hub/mingchao-those-things-skill](https://github.com/qbdx-hub/mingchao-those-things-skill) | 当年明月《明朝那些事儿》 | 7 |
+| [qbdx-hub/sunzi-bingfa-skill](https://github.com/qbdx-hub/sunzi-bingfa-skill) | 《孙子兵法》 | 8 |
+| [qbdx-hub/zhouyi-skill](https://github.com/qbdx-hub/zhouyi-skill) | 《周易》 | 8 |
+| [qbdx-hub/high-math-vol1-ch1-skill](https://github.com/qbdx-hub/high-math-vol1-ch1-skill) | 高等数学上册第一章 | 8 |
 
 后续计划蒸馏更多高价值书籍。候选书单包括但不限于：君主论。
 
@@ -148,6 +154,12 @@ cangjie-skill 是一个更大的 skill 生态的一部分：
 - [Huangdi Neijing Skill](https://github.com/kangarooking/huangdi-neijing-skill) — 《黄帝内经》素问12+灵枢10共22个思维方法 skill
 - [First Principles Skill](https://github.com/kangarooking/first-principles-skill) — 《第一性原理》的 10 个认知拆解、破界创新与组织刷新 skill
 - [Mao Selected Works Skill](https://github.com/kangarooking/mao-selected-works-skill) — 《毛泽东选集》第 1-5 卷的 25 个认知、战略、组织与执行方法 skill
+- [qbdx-hub Buffett Letters Skill](https://github.com/qbdx-hub/buffett-letters-skill) — 沃伦·巴菲特 1957-2023 年致股东信的 20 个投资与资本配置 skill
+- [qbdx-hub Wo Yu Di Tan Skill](https://github.com/qbdx-hub/wo-yu-di-tan-skill) — 《我与地坛》的 6 个限制、苦难、写作与自我安放 skill
+- [qbdx-hub Mingchao Those Things Skill](https://github.com/qbdx-hub/mingchao-those-things-skill) — 《明朝那些事儿》的 7 个权力结构、制度失灵与历史表达 skill
+- [qbdx-hub Sunzi Bingfa Skill](https://github.com/qbdx-hub/sunzi-bingfa-skill) — 《孙子兵法》的 8 个战略判断、资源控制与行动选择 skill
+- [qbdx-hub Zhouyi Skill](https://github.com/qbdx-hub/zhouyi-skill) — 《周易》的 8 个处境诊断、时位判断与进退边界 skill
+- [qbdx-hub High Math Vol. 1 Chapter 1 Skill](https://github.com/qbdx-hub/high-math-vol1-ch1-skill) — 高等数学上册第一章的 8 个极限、无穷小与连续性学习 skill
 - [book2startup](https://github.com/ace3000chao/book2startup) — 经作者同意引入的外部来源，包含《精益创业》《孙子兵法》《庄子》《易经》相关 skills
 - [book2skill](https://github.com/shenqistart/book2skill) — 经作者同意引入的外部来源，包含《缠论》《茶经》相关 AI-Agent skills
 
@@ -178,22 +190,4 @@ cangjie-skill 是一个更大的 skill 生态的一部分：
 ## License
 
 MIT. See [LICENSE](./LICENSE).
-
-
-<!-- cangjie-book-skill-examples:start -->
-## qbdx-hub 整书 Skill 示例
-
-下面这些仓库是使用 Cangjie Skill 流程蒸馏并开源的整书/章节 skill 包，可以作为 `book2skill` 输出示例参考：
-
-| 书目 | Skill 仓库 | Skill 数量 |
-|---|---|---:|
-| 沃伦·巴菲特 1957-2023 年致股东信 | [buffett-letters-skill](https://github.com/qbdx-hub/buffett-letters-skill) | 20 |
-| 史铁生《我与地坛》 | [wo-yu-di-tan-skill](https://github.com/qbdx-hub/wo-yu-di-tan-skill) | 6 |
-| 当年明月《明朝那些事儿》 | [mingchao-those-things-skill](https://github.com/qbdx-hub/mingchao-those-things-skill) | 7 |
-| 《孙子兵法》 | [sunzi-bingfa-skill](https://github.com/qbdx-hub/sunzi-bingfa-skill) | 8 |
-| 《周易》 | [zhouyi-skill](https://github.com/qbdx-hub/zhouyi-skill) | 8 |
-| 高等数学上册第一章 | [high-math-vol1-ch1-skill](https://github.com/qbdx-hub/high-math-vol1-ch1-skill) | 8 |
-
-这些仓库保留蒸馏后的 `BOOK_OVERVIEW.md`、`INDEX.md`、`candidates/`、`*/SKILL.md` 和测试提示；原书 PDF、EPUB 和全文源文件没有随仓库发布。
-<!-- cangjie-book-skill-examples:end -->
 

--- a/README.md
+++ b/README.md
@@ -178,3 +178,20 @@ cangjie-skill 是一个更大的 skill 生态的一部分：
 ## License
 
 MIT. See [LICENSE](./LICENSE).
+
+<!-- cangjie-book-skill-examples:start -->
+## Open Book Skill Examples
+
+The following repositories are public book or chapter skill packages distilled with the Cangjie Skill workflow. They can be used as ook2skill output examples:
+
+| Book | Skill Repository | Skill Count |
+|---|---|---:|
+| Buffett Shareholder Letters | [buffett-letters-skill](https://github.com/qbdx-hub/buffett-letters-skill) | 20 |
+| Wo Yu Di Tan | [wo-yu-di-tan-skill](https://github.com/qbdx-hub/wo-yu-di-tan-skill) | 6 |
+| Mingchao Those Things | [mingchao-those-things-skill](https://github.com/qbdx-hub/mingchao-those-things-skill) | 7 |
+| Sunzi Bingfa | [sunzi-bingfa-skill](https://github.com/qbdx-hub/sunzi-bingfa-skill) | 8 |
+| Zhouyi | [zhouyi-skill](https://github.com/qbdx-hub/zhouyi-skill) | 8 |
+| High Math Vol. 1 Chapter 1 | [high-math-vol1-ch1-skill](https://github.com/qbdx-hub/high-math-vol1-ch1-skill) | 8 |
+
+These repositories keep the distilled BOOK_OVERVIEW.md, INDEX.md, candidates/, */SKILL.md, and test prompts. Original PDFs, EPUBs, and full book source text are intentionally excluded.
+<!-- cangjie-book-skill-examples:end -->

--- a/README.md
+++ b/README.md
@@ -179,19 +179,21 @@ cangjie-skill 是一个更大的 skill 生态的一部分：
 
 MIT. See [LICENSE](./LICENSE).
 
+
 <!-- cangjie-book-skill-examples:start -->
-## Open Book Skill Examples
+## qbdx-hub 整书 Skill 示例
 
-The following repositories are public book or chapter skill packages distilled with the Cangjie Skill workflow. They can be used as ook2skill output examples:
+下面这些仓库是使用 Cangjie Skill 流程蒸馏并开源的整书/章节 skill 包，可以作为 `book2skill` 输出示例参考：
 
-| Book | Skill Repository | Skill Count |
+| 书目 | Skill 仓库 | Skill 数量 |
 |---|---|---:|
-| Buffett Shareholder Letters | [buffett-letters-skill](https://github.com/qbdx-hub/buffett-letters-skill) | 20 |
-| Wo Yu Di Tan | [wo-yu-di-tan-skill](https://github.com/qbdx-hub/wo-yu-di-tan-skill) | 6 |
-| Mingchao Those Things | [mingchao-those-things-skill](https://github.com/qbdx-hub/mingchao-those-things-skill) | 7 |
-| Sunzi Bingfa | [sunzi-bingfa-skill](https://github.com/qbdx-hub/sunzi-bingfa-skill) | 8 |
-| Zhouyi | [zhouyi-skill](https://github.com/qbdx-hub/zhouyi-skill) | 8 |
-| High Math Vol. 1 Chapter 1 | [high-math-vol1-ch1-skill](https://github.com/qbdx-hub/high-math-vol1-ch1-skill) | 8 |
+| 沃伦·巴菲特 1957-2023 年致股东信 | [buffett-letters-skill](https://github.com/qbdx-hub/buffett-letters-skill) | 20 |
+| 史铁生《我与地坛》 | [wo-yu-di-tan-skill](https://github.com/qbdx-hub/wo-yu-di-tan-skill) | 6 |
+| 当年明月《明朝那些事儿》 | [mingchao-those-things-skill](https://github.com/qbdx-hub/mingchao-those-things-skill) | 7 |
+| 《孙子兵法》 | [sunzi-bingfa-skill](https://github.com/qbdx-hub/sunzi-bingfa-skill) | 8 |
+| 《周易》 | [zhouyi-skill](https://github.com/qbdx-hub/zhouyi-skill) | 8 |
+| 高等数学上册第一章 | [high-math-vol1-ch1-skill](https://github.com/qbdx-hub/high-math-vol1-ch1-skill) | 8 |
 
-These repositories keep the distilled BOOK_OVERVIEW.md, INDEX.md, candidates/, */SKILL.md, and test prompts. Original PDFs, EPUBs, and full book source text are intentionally excluded.
+这些仓库保留蒸馏后的 `BOOK_OVERVIEW.md`、`INDEX.md`、`candidates/`、`*/SKILL.md` 和测试提示；原书 PDF、EPUB 和全文源文件没有随仓库发布。
 <!-- cangjie-book-skill-examples:end -->
+


### PR DESCRIPTION
## What changed

This PR adds a README section linking to the qbdx-hub book skill repositories distilled with the Cangjie Skill workflow.

## Notes

- Links published skill repositories for Buffett Letters, Wo Yu Di Tan, Mingchao Those Things, Sunzi Bingfa, Zhouyi, and High Math Vol. 1 Chapter 1.
- Notes that source PDFs, EPUBs, and full book text are intentionally excluded from the published repositories.

## Validation

- Published repositories were created/updated through the GitHub API.
- README was updated in a fork branch before opening this PR.