### PR TITLE
新增 en-zh-translation-polish（用 cangjie-skill 蒸馏叶子南英译汉方法论）

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ RIA-TV++ 这个名字拆开看：
 | [qbdx-hub/sunzi-bingfa-skill](https://github.com/qbdx-hub/sunzi-bingfa-skill) | 《孙子兵法》 | 8 |
 | [qbdx-hub/zhouyi-skill](https://github.com/qbdx-hub/zhouyi-skill) | 《周易》 | 8 |
 | [qbdx-hub/high-math-vol1-ch1-skill](https://github.com/qbdx-hub/high-math-vol1-ch1-skill) | 高等数学上册第一章 | 8 |
+| [HoraceLuBFA/en-zh-translation-polish](https://github.com/HoraceLuBFA/en-zh-translation-polish) | 叶子南《高级英汉翻译理论与实践》(第4版) | 1 |
 
 后续计划蒸馏更多高价值书籍。候选书单包括但不限于：君主论。
 
@@ -162,6 +163,7 @@ cangjie-skill 是一个更大的 skill 生态的一部分：
 - [qbdx-hub High Math Vol. 1 Chapter 1 Skill](https://github.com/qbdx-hub/high-math-vol1-ch1-skill) — 高等数学上册第一章的 8 个极限、无穷小与连续性学习 skill
 - [book2startup](https://github.com/ace3000chao/book2startup) — 经作者同意引入的外部来源，包含《精益创业》《孙子兵法》《庄子》《易经》相关 skills
 - [book2skill](https://github.com/shenqistart/book2skill) — 经作者同意引入的外部来源，包含《缠论》《茶经》相关 AI-Agent skills
+- [en-zh-translation-polish](https://github.com/HoraceLuBFA/en-zh-translation-polish) — 叶子南《高级英汉翻译理论与实践》(第4版) 蒸馏的英译汉润色 + 英中对照 skill（社区贡献：1 个 skill + 3 张引擎参考表）
 
 ## 贡献者
 


### PR DESCRIPTION
用 cangjie-skill 把叶子南《高级英汉翻译理论与实践》(第4版) 蒸馏成了一个英译汉 skill：译出地道、无翻译腔的中文，并产出逐段英中对照。仓库 README 已致谢 cangjie-skill。

本 PR 同步更新两处，保持一致：
- `已生成的 skill packs` 表格新增一行；
- `More Skills` 列表新增一条。

- 仓库：https://github.com/HoraceLuBFA/en-zh-translation-polish
- 安装：`npx skills add -g HoraceLuBFA/en-zh-translation-polish`
- 构成：1 个可调用 skill + 3 张引擎参考表（病症 / 技巧 / 文本分析），MIT 许可

说明：这是单个 skill（非多 skill pack），`Skills 数` 记为 1；若您更希望放到「补充外部来源」一节或调整表述，我照改。