### PR TITLE
docs: add X growth skills

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -83,6 +83,7 @@ The name RIA-TV++ breaks down as:
 | [influence-skill](https://github.com/kangarooking/influence-skill) | Influence | 12 |
 | [1000-true-fans-skill](https://github.com/kangarooking/1000-true-fans-skill) | 1000 True Fans | 13 |
 | [system-prompt-skills](https://github.com/kangarooking/system-prompt-skills) | 165 AI product system prompts | 15 |
+| [X-growth-skills](https://github.com/kangarooking/X-growth-skills) | Practical X (Twitter) account launch, content growth, algorithm, engagement, and monetization resources | 15 |
 | [poor-charlies-almanack-skill](https://github.com/kangarooking/poor-charlies-almanack-skill) | Poor Charlie's Almanack | 12 |
 | [no-rules-rules-skill](https://github.com/kangarooking/no-rules-rules-skill) | No Rules Rules | 10 |
 | Huangdi Neijing Suwen (in this project) | Huangdi Neijing: Suwen | 10 |
@@ -142,6 +143,7 @@ They interlock: nuwa distills people, cangjie distills books, darwin keeps them 
 - [Influence Skill](https://github.com/kangarooking/influence-skill) — 12 persuasion psychology, compliance mechanism, and defensive judgment skills from *Influence*
 - [1000 True Fans Skill](https://github.com/kangarooking/1000-true-fans-skill) — 13 personal branding, true fan development, and trust-based monetization skills from *1000 True Fans*
 - [System Prompt Skills](https://github.com/kangarooking/system-prompt-skills) — 15 system prompt design skills distilled from 165 AI product system prompts
+- [X Growth Skills](https://github.com/kangarooking/X-growth-skills) — 15 skills for X account launch, content, algorithms, engagement, review, and monetization
 - Huangdi Neijing Suwen Skill (in this project) — 10 traditional Chinese medicine observation and regulation skills from *Huangdi Neijing: Suwen*
 - Huangdi Neijing Lingshu Skill (in this project) — 8 body-mind regulation and syndrome differentiation skills from *Huangdi Neijing: Lingshu*
 - [First Principles Skill](https://github.com/kangarooking/first-principles-skill) — 10 skills on axiomatic reasoning, boundary-breaking innovation, and organizational refresh from *First Principles*

--- a/README.ja.md
+++ b/README.ja.md
@@ -83,6 +83,7 @@ RIA-TV++ の名前の由来：
 | [influence-skill](https://github.com/kangarooking/influence-skill) | 『Influence』 | 12 |
 | [1000-true-fans-skill](https://github.com/kangarooking/1000-true-fans-skill) | 『1000 True Fans』 | 13 |
 | [system-prompt-skills](https://github.com/kangarooking/system-prompt-skills) | 165個のAI製品システムプロンプト | 15 |
+| [X-growth-skills](https://github.com/kangarooking/X-growth-skills) | X（Twitter）のアカウント立ち上げ、コンテンツ成長、アルゴリズム、交流、収益化の実践資料 | 15 |
 | [poor-charlies-almanack-skill](https://github.com/kangarooking/poor-charlies-almanack-skill) | 貧しきチャーリーの格言 | 12 |
 | [no-rules-rules-skill](https://github.com/kangarooking/no-rules-rules-skill) | No Rules Rules | 10 |
 | 黄帝内経・素問（本プロジェクト内） | 『黄帝内経・素問』 | 10 |
@@ -142,6 +143,7 @@ cangjie-skill はより大きなスキルエコシステムの一部です：
 - [Influence Skill](https://github.com/kangarooking/influence-skill) — 『Influence』から抽出した12個の説得心理・コンプライアンス機制・防御判断スキル
 - [1000 True Fans Skill](https://github.com/kangarooking/1000-true-fans-skill) — 『1000 True Fans』から抽出した13個の個人ブランド・真のファン育成・信頼ベース収益化スキル
 - [System Prompt Skills](https://github.com/kangarooking/system-prompt-skills) — 165個のAI製品システムプロンプトから抽出した15個のシステムプロンプト設計スキル
+- [X Growth Skills](https://github.com/kangarooking/X-growth-skills) — Xの立ち上げ、コンテンツ、アルゴリズム、交流、分析、収益化の15スキル
 - Huangdi Neijing Suwen Skill（本プロジェクト内）— 『黄帝内経・素問』から抽出した10個の中医観察・調整スキル
 - Huangdi Neijing Lingshu Skill（本プロジェクト内）— 『黄帝内経・霊枢』から抽出した8個の心身調整・弁証スキル
 - [First Principles Skill](https://github.com/kangarooking/first-principles-skill) — 『第一性原理』から抽出した10個の公理化思考・破界イノベーション・組織刷新スキル

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ RIA-TV++ 这个名字拆开看：
 | [influence-skill](https://github.com/kangarooking/influence-skill) | 《影响力》 | 12 |
 | [1000-true-fans-skill](https://github.com/kangarooking/1000-true-fans-skill) | 《1000个铁粉》 | 13 |
 | [system-prompt-skills](https://github.com/kangarooking/system-prompt-skills) | 165 个 AI 产品系统提示词 | 15 |
+| [X-growth-skills](https://github.com/kangarooking/X-growth-skills) | X（Twitter）起号、内容增长、算法、互动与变现实战资料集 | 15 |
 | [poor-charlies-almanack-skill](https://github.com/kangarooking/poor-charlies-almanack-skill) | 《穷查理宝典》 | 12 |
 | [no-rules-rules-skill](https://github.com/kangarooking/no-rules-rules-skill) | 《不拘一格：网飞的自由与责任工作法》 | 10 |
 | [huangdi-neijing-skill](https://github.com/kangarooking/huangdi-neijing-skill) | 《黄帝内经》（素问+灵枢） | 22 |
@@ -163,6 +164,7 @@ cangjie-skill 是一个更大的 skill 生态的一部分：
 - [Influence Skill](https://github.com/kangarooking/influence-skill) — 《影响力》的 12 个说服心理、顺从机制与防御判断 skill
 - [1000 True Fans Skill](https://github.com/kangarooking/1000-true-fans-skill) — 《1000个铁粉》的 13 个个人品牌、铁粉养成与信任变现 skill
 - [System Prompt Skills](https://github.com/kangarooking/system-prompt-skills) — 从 165 个 AI 产品系统提示词蒸馏出的 15 个 system prompt 设计 skill
+- [X Growth Skills](https://github.com/kangarooking/X-growth-skills) — X 起号、内容、算法、互动、复盘与变现的 15 个运营 skill
 - [Huangdi Neijing Skill](https://github.com/kangarooking/huangdi-neijing-skill) — 《黄帝内经》素问12+灵枢10共22个思维方法 skill
 - [First Principles Skill](https://github.com/kangarooking/first-principles-skill) — 《第一性原理》的 10 个认知拆解、破界创新与组织刷新 skill
 - [Mao Selected Works Skill](https://github.com/kangarooking/mao-selected-works-skill) — 《毛泽东选集》第 1-5 卷的 25 个认知、战略、组织与执行方法 skill


### PR DESCRIPTION
## What changed

- Add `X-growth-skills` to the generated skill packs table.
- Add it to the More Skills index.
- Keep the Chinese, English, and Japanese READMEs in sync.

## Why

`X-growth-skills` is a new public pack generated with cangjie-skill. It contains 15 practical skills for X account launch, content growth, recommendation algorithms, engagement, review, and monetization.

Repository: https://github.com/kangarooking/X-growth-skills

## Validation

- Confirmed the linked repository is public.
- Ran `git diff --check`.
- Reviewed the three README diffs and confirmed only the intended index entries changed.
