### PR TITLE
docs: add official website entry to all READMEs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,6 +2,12 @@
 
 Distill a book into a set of executable AI skills.
 
+## Official Website
+
+🌐 [Visit the Cangjie Skill official website](https://cangjie-skill.pages.dev/)
+
+The website provides visual Skill Pack browsing, a beginner-friendly usage guide, Skill detail pages, and a contribution submission entry. This GitHub repository remains the sole source for cangjie-skill code, methodology, and templates; the website provides presentation, navigation, and usage guidance.
+
 ## Why This Exists
 
 There's a recent viral idea: distilling colleagues into AI skills. Even after someone leaves, their experience, tone, and work style can be partially replicated by AI. [nuwa-skill](https://github.com/alchaincyf/nuwa-skill) does exactly this — creating "human skills" like an Elon Musk skill or a Warren Buffett skill. The companion [darwin-skill](https://github.com/alchaincyf/darwin-skill) handles automatic skill evolution.

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,6 +2,12 @@
 
 本を実行可能な AI スキルのセットに蒸留します。
 
+## 公式サイト
+
+🌐 [Cangjie Skill 公式サイトを見る](https://cangjie-skill.pages.dev/)
+
+公式サイトでは、Skill Pack の視覚的な閲覧、初めての方向けの利用ガイド、Skill 詳細、コミュニティへの提出窓口を提供します。cangjie-skill のコード、方法論、テンプレートの唯一のソースは引き続きこの GitHub リポジトリです。公式サイトは展示、ナビゲーション、利用ガイドを担います。
+
 ## なぜこれを作ったのか
 
 最近バズったアイデアがあります：同僚を AI スキルに蒸留する。人が離職しても、その人の経験、口調、仕事のスタイルが AI によってある程度再現できる。[nuwa-skill](https://github.com/alchaincyf/nuwa-skill) はまさにこれを行う——イーロン・マスク skill やウォーレン・バフェット skill のような「人間 skill」を生成します。コンパニオンの [darwin-skill](https://github.com/alchaincyf/darwin-skill) はスキルの自動進化を担当します。

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@
 
 </div>
 
+## 官方网站
+
+🌐 [访问 Cangjie Skill 官方网站](https://cangjie-skill.pages.dev/)
+
+官网提供 Skill Packs 可视化浏览、从零开始的使用教程、Skill 详情与生态共建提交入口。GitHub 仓库仍是 cangjie-skill 代码、方法论和模板的唯一来源，官网负责展示、导航与使用指引。
+
 ## 为什么做这件事
 
 最近有一个很火的 idea：把同事蒸馏成 skill。即便一个人离职了，他的经验、语气、工作方式都会被 AI 一定程度替代。[nuwa-skill](https://github.com/alchaincyf/nuwa-skill) 就是做这件事的——创造"人类 skill"，比如马斯克 skill、巴菲特 skill。配套的 [darwin-skill](https://github.com/alchaincyf/darwin-skill) 负责让这些 skill 自动进化。


### PR DESCRIPTION
## What changed

- Add the public Cangjie Skill website link near the top of README.md, README.en.md, and README.ja.md.
- Explain that the website provides visual Skill browsing, beginner guidance, Skill detail pages, and a contribution submission entry.
- Clarify that this GitHub repository remains the sole source for code, methodology, and templates.

## Why

The official website is publicly available and should be discoverable from every README language without adding the website source code to this repository.

## Validation

- Confirmed the PR changes only the three README files.
- Ran git diff --check successfully.
- Verified all three README variants contain https://cangjie-skill.pages.dev/.
- Verified the public website returns HTTP 200.