### PR TITLE
docs: update official website URL

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -4,7 +4,7 @@ Distill a book into a set of executable AI skills.
 
 ## Official Website
 
-🌐 [Visit the Cangjie Skill official website](https://cangjie-skill.pages.dev/)
+🌐 [Visit the Cangjie Skill official website](https://cangjie-skill.com/)
 
 The website provides visual Skill Pack browsing, a beginner-friendly usage guide, Skill detail pages, and a contribution submission entry. This GitHub repository remains the sole source for cangjie-skill code, methodology, and templates; the website provides presentation, navigation, and usage guidance.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,7 @@
 
 ## 公式サイト
 
-🌐 [Cangjie Skill 公式サイトを見る](https://cangjie-skill.pages.dev/)
+🌐 [Cangjie Skill 公式サイトを見る](https://cangjie-skill.com/)
 
 公式サイトでは、Skill Pack の視覚的な閲覧、初めての方向けの利用ガイド、Skill 詳細、コミュニティへの提出窓口を提供します。cangjie-skill のコード、方法論、テンプレートの唯一のソースは引き続きこの GitHub リポジトリです。公式サイトは展示、ナビゲーション、利用ガイドを担います。
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## 官方网站
 
-🌐 [访问 Cangjie Skill 官方网站](https://cangjie-skill.pages.dev/)
+🌐 [访问 Cangjie Skill 官方网站](https://cangjie-skill.com/)
 
 官网提供 Skill Packs 可视化浏览、从零开始的使用教程、Skill 详情与生态共建提交入口。GitHub 仓库仍是 cangjie-skill 代码、方法论和模板的唯一来源，官网负责展示、导航与使用指引。
 


### PR DESCRIPTION
## What changed

- Replace the former `cangjie-skill.pages.dev` official-site link with `https://cangjie-skill.com/`.
- Keep the Chinese, English, and Japanese README variants aligned.

## Why

The project now uses `cangjie-skill.com` as its official website address.

## Impact

README visitors are directed to the current official domain. No code or workflow behavior changes.

## Validation

- `git diff --check`
- Confirmed the new URL appears once in each README variant
- Confirmed the former Pages URL no longer appears in the three README files
