### PR TITLE
docs: add sunyuchen-skill

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -96,6 +96,7 @@ RIA-TV++ の名前の由来：
 | [1000-true-fans-skill](https://github.com/kangarooking/1000-true-fans-skill) | 『1000 True Fans』 | 13 |
 | [system-prompt-skills](https://github.com/kangarooking/system-prompt-skills) | 165個のAI製品システムプロンプト | 15 |
 | [X-growth-skills](https://github.com/kangarooking/X-growth-skills) | X（Twitter）のアカウント立ち上げ、コンテンツ成長、アルゴリズム、交流、収益化の実践資料 | 15 |
+| [sunyuchen-skill](https://github.com/kangarooking/sunyuchen-skill) | “sunyuchen” と名付けられた単篇の物語文章サンプル | 1（7つの能力） |
 | [poor-charlies-almanack-skill](https://github.com/kangarooking/poor-charlies-almanack-skill) | 貧しきチャーリーの格言 | 12 |
 | [no-rules-rules-skill](https://github.com/kangarooking/no-rules-rules-skill) | No Rules Rules | 10 |
 | 黄帝内経・素問（本プロジェクト内） | 『黄帝内経・素問』 | 10 |
@@ -156,6 +157,7 @@ cangjie-skill はより大きなスキルエコシステムの一部です：
 - [1000 True Fans Skill](https://github.com/kangarooking/1000-true-fans-skill) — 『1000 True Fans』から抽出した13個の個人ブランド・真のファン育成・信頼ベース収益化スキル
 - [System Prompt Skills](https://github.com/kangarooking/system-prompt-skills) — 165個のAI製品システムプロンプトから抽出した15個のシステムプロンプト設計スキル
 - [X Growth Skills](https://github.com/kangarooking/X-growth-skills) — Xの立ち上げ、コンテンツ、アルゴリズム、交流、分析、収益化の15スキル
+- [sunyuchen-skill](https://github.com/kangarooking/sunyuchen-skill) — 数字による冷たい導入、運用の細部、短い会話、感情の余白、物のコールバックを扱う抑制的な物語文章 Skill
 - Huangdi Neijing Suwen Skill（本プロジェクト内）— 『黄帝内経・素問』から抽出した10個の中医観察・調整スキル
 - Huangdi Neijing Lingshu Skill（本プロジェクト内）— 『黄帝内経・霊枢』から抽出した8個の心身調整・弁証スキル
 - [First Principles Skill](https://github.com/kangarooking/first-principles-skill) — 『第一性原理』から抽出した10個の公理化思考・破界イノベーション・組織刷新スキル

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The name RIA-TV++ breaks down as:
 | [1000-true-fans-skill](https://github.com/kangarooking/1000-true-fans-skill) | 1000 True Fans | 13 |
 | [system-prompt-skills](https://github.com/kangarooking/system-prompt-skills) | 165 AI product system prompts | 15 |
 | [X-growth-skills](https://github.com/kangarooking/X-growth-skills) | Practical X (Twitter) account launch, content growth, algorithm, engagement, and monetization resources | 15 |
+| [sunyuchen-skill](https://github.com/kangarooking/sunyuchen-skill) | A single narrative writing sample labeled “sunyuchen” | 1 (7 capabilities) |
 | [poor-charlies-almanack-skill](https://github.com/kangarooking/poor-charlies-almanack-skill) | Poor Charlie's Almanack | 12 |
 | [no-rules-rules-skill](https://github.com/kangarooking/no-rules-rules-skill) | No Rules Rules | 10 |
 | [huangdi-neijing-skill](https://github.com/kangarooking/huangdi-neijing-skill) | *Huangdi Neijing* (*Suwen* + *Lingshu*) | 22 |
@@ -200,6 +201,7 @@ They interlock: nuwa distills people, cangjie distills books, darwin keeps them 
 - [1000 True Fans Skill](https://github.com/kangarooking/1000-true-fans-skill) — 13 personal branding, true fan development, and trust-based monetization skills from *1000 True Fans*
 - [System Prompt Skills](https://github.com/kangarooking/system-prompt-skills) — 15 system prompt design skills distilled from 165 AI product system prompts
 - [X Growth Skills](https://github.com/kangarooking/X-growth-skills) — 15 skills for X account launch, content, algorithms, engagement, review, and monetization
+- [sunyuchen-skill](https://github.com/kangarooking/sunyuchen-skill) — A restrained narrative writing skill covering cold opens, operational detail, short dialogue, emotional restraint, and object callbacks
 - [Huangdi Neijing Skill](https://github.com/kangarooking/huangdi-neijing-skill) — 22 methodology skills from *Huangdi Neijing*, including 12 from *Suwen* and 10 from *Lingshu*
 - [First Principles Skill](https://github.com/kangarooking/first-principles-skill) — 10 skills on axiomatic reasoning, boundary-breaking innovation, and organizational refresh from *First Principles*
 - [Mao Selected Works Skill](https://github.com/kangarooking/mao-selected-works-skill) — 25 cognition, strategy, organization, and execution skills from *Selected Works of Mao Zedong*

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -132,6 +132,7 @@ RIA-TV++ 这个名字拆开看：
 | [1000-true-fans-skill](https://github.com/kangarooking/1000-true-fans-skill) | 《1000个铁粉》 | 13 |
 | [system-prompt-skills](https://github.com/kangarooking/system-prompt-skills) | 165 个 AI 产品系统提示词 | 15 |
 | [X-growth-skills](https://github.com/kangarooking/X-growth-skills) | X（Twitter）起号、内容增长、算法、互动与变现实战资料集 | 15 |
+| [sunyuchen-skill](https://github.com/kangarooking/sunyuchen-skill) | “sunyuchen” 单篇叙事写作样本 | 1（7 个能力） |
 | [poor-charlies-almanack-skill](https://github.com/kangarooking/poor-charlies-almanack-skill) | 《穷查理宝典》 | 12 |
 | [no-rules-rules-skill](https://github.com/kangarooking/no-rules-rules-skill) | 《不拘一格：网飞的自由与责任工作法》 | 10 |
 | [huangdi-neijing-skill](https://github.com/kangarooking/huangdi-neijing-skill) | 《黄帝内经》（素问+灵枢） | 22 |
@@ -200,6 +201,7 @@ cangjie-skill 是一个更大的 skill 生态的一部分：
 - [1000 True Fans Skill](https://github.com/kangarooking/1000-true-fans-skill) — 《1000个铁粉》的 13 个个人品牌、铁粉养成与信任变现 skill
 - [System Prompt Skills](https://github.com/kangarooking/system-prompt-skills) — 从 165 个 AI 产品系统提示词蒸馏出的 15 个 system prompt 设计 skill
 - [X Growth Skills](https://github.com/kangarooking/X-growth-skills) — X 起号、内容、算法、互动、复盘与变现的 15 个运营 skill
+- [sunyuchen-skill](https://github.com/kangarooking/sunyuchen-skill) — 覆盖数字冷开场、后勤细节、短对话、情绪留白与物件回环的克制叙事写作 skill
 - [Huangdi Neijing Skill](https://github.com/kangarooking/huangdi-neijing-skill) — 《黄帝内经》素问12+灵枢10共22个思维方法 skill
 - [First Principles Skill](https://github.com/kangarooking/first-principles-skill) — 《第一性原理》的 10 个认知拆解、破界创新与组织刷新 skill
 - [Mao Selected Works Skill](https://github.com/kangarooking/mao-selected-works-skill) — 《毛泽东选集》第 1-5 卷的 25 个认知、战略、组织与执行方法 skill


### PR DESCRIPTION
## Summary

- add the public `sunyuchen-skill` repository to the generated Skill Packs table
- add it to More Skills
- keep English, Simplified Chinese, and Japanese README indexes aligned

## Verification

- public repository is reachable on GitHub
- each README contains the repository link in both index sections
- `git diff --check` passes